### PR TITLE
Detect when Cirrus job runs out of CI minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ return values:
   - 0: The cirrus job was successful
   - 1: The job failed
   - 2: Error in 'cirrus-run'
+  - 3: The Cirrus CI job ran out of CI minutes
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ optional arguments:
                         marker per line. If any marker is found in Cirrus CI
                         output for a failed build, the build is retried once
                         more. Default: $CIRRUS_FLAKY_MARKERS_FILE
+
+return values:
+  - 0: The cirrus job was successful
+  - 1: The job failed
+  - 2: Error in 'cirrus-run'
 ```
 
 

--- a/cirrus_run/queries.py
+++ b/cirrus_run/queries.py
@@ -110,7 +110,7 @@ def wait_build(api, build_id: str, delay=3, abort=60*60, credits_error_message=N
     while time() < time_start + abort:
         response = api(query, params)
         status = response['build']['status']
-        log.info('build {}: {}'.format(build_id, status))
+        log.info('build https://cirrus-ci.com/build/{}: {}'.format(build_id, status))
         if status in {'COMPLETED'}:
             return True
         if status in {'CREATED', 'TRIGGERED', 'EXECUTING'}:


### PR DESCRIPTION
In the 'libvirt' project we started to run out of the free Cirrus CI credits at the end of the month. It's annoying as it looks exactly like the job has failed.

These patches add detection of the state and introduce a new return code so that it can be handled from scripts.